### PR TITLE
Add option to append label

### DIFF
--- a/src/webserver.h
+++ b/src/webserver.h
@@ -62,8 +62,9 @@ const char index_html[] PROGMEM = R""""(
         %QUERY%
         <h3>New Query</h3>
         <form method="POST" action="/set-query">
-            <label for="label">Label: (optional, only if you have a second matrix connected)</label><br>
-            <input type="text" id="label" name="label" maxlength="10" size="10" value="%LABEL%"><br><br>
+            <label for="label">Label: </label><br>
+            <input type="text" id="label" name="label" maxlength="10" size="10" value="%LABEL%"><br>
+            <input type="checkbox" id="useSecondMatrix" name="useSecondMatrix" %USESECONDMATRIX%><label for="useSecondMatrix">Use 2nd Matrix for label</label><br><br>
             <label for="query">New Query:</label><br>
             <input type="text" id="query" name="query" style="width: 90%%;"><br><br>
             <label for="red">Red:</label><input type="number" id="red" name="red" min="0" max="255" size="3" value="%RED%">


### PR DESCRIPTION

![Screenshot 2023-05-12 at 4 38 46 PM](https://github.com/slim-bean/esp32-metrics-matrix/assets/1533128/9f9861f9-e4ac-4d1a-8b9d-39f36435c760)
Adds a checkbox on if we should use the second matrix for the label or not

If its unchecked and there is a label, append it onto the metric.

If the metric's last digit is a zero, change it into a space for clarity.

It's easier to run out of space on the matrix this way, but at least with this they can use a rounding function to make it look better. 

![IMG_9402](https://github.com/slim-bean/esp32-metrics-matrix/assets/1533128/8d2e2701-efbb-4897-a7f2-32ba2602a7b5)
![IMG_9403](https://github.com/slim-bean/esp32-metrics-matrix/assets/1533128/f8f8cdcb-0bb7-4274-be20-0942e1dc5ae0)
